### PR TITLE
update .net core unobtrusive ajax rendering and updated examples

### DIFF
--- a/examples/X.PagedList.Mvc.Example.Core/Controllers/HomeController.cs
+++ b/examples/X.PagedList.Mvc.Example.Core/Controllers/HomeController.cs
@@ -7,9 +7,23 @@ namespace X.PagedList.Mvc.Example.Core.Controllers
     {
         public IActionResult Index(int page = 1)
         {
-            var listPaged = GetPagedNames(page); // GetPagedNames is found in BaseController
+            var listPaged = GetPagedNames(page);
+            ViewBag.Names = null;//listPaged;
+            return View();
+        }
+
+        public IActionResult AjaxIndex(int page = 1)
+        {
+            var listPaged = GetPagedNames(page);
             ViewBag.Names = listPaged;
             return View();
+        }
+
+        public IActionResult GetOnePageOfNames(int page = 1)
+        {
+            var listPaged = GetPagedNames(page);
+            ViewBag.Names = listPaged;
+            return PartialView("_NameListPartial", ViewBag.Names);
         }
 
         public IActionResult Error()

--- a/examples/X.PagedList.Mvc.Example.Core/Views/Home/AjaxIndex.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Home/AjaxIndex.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    ViewBag.Title = "Product Listing";
+}
+
+@using X.PagedList; @*import this so we can cast our list to IPagedList (only necessary because ViewBag is dynamic)*@
+
+<!-- loop through each of your products and display it however you want. we're just printing the name here -->
+<h2>List of Products</h2>
+<div id="nameListContainer">
+    @Html.Partial("_NameListPartial", (IPagedList<string>)ViewBag.Names)
+</div>

--- a/examples/X.PagedList.Mvc.Example.Core/Views/Home/Index.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Home/Index.cshtml
@@ -1,0 +1,21 @@
+﻿@{
+    ViewBag.Title = "Product Listing";
+}
+
+@using X.PagedList.Mvc.Core; @*import this so we get our HTML Helper*@
+@using X.PagedList; @*import this so we can cast our list to IPagedList (only necessary because ViewBag is dynamic)*@
+
+<!-- import the included stylesheet for some (very basic) default styling -->
+<link href="/Content/PagedList.css" rel="stylesheet" type="text/css" />
+
+<!-- loop through each of your products and display it however you want. we're just printing the name here -->
+<h2>List of Products</h2>
+<ul>
+    @foreach (var name in ViewBag.Names)
+    {
+        <li>@name</li>
+    }
+</ul>
+
+<!-- output a paging control that lets the user navigation to the previous page, next page, etc -->
+@Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("Index", new { page }))

--- a/examples/X.PagedList.Mvc.Example.Core/Views/Home/_NameListPartial.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Home/_NameListPartial.cshtml
@@ -1,0 +1,13 @@
+﻿@model IPagedList<string>
+@using X.PagedList.Mvc.Core.Fake; @*use this for the fake AjaxOptions since ajax helpers were dropped in .net core*@
+@using X.PagedList.Mvc.Core; @*import this so we get our HTML Helper*@
+@using X.PagedList; @*import this so we can cast our list to IPagedList (only necessary because ViewBag is dynamic)*@
+
+<ul>
+    @foreach (var name in Model)
+    {
+        <li>@name</li>
+    }
+</ul>
+
+@Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("GetOnePageOfNames", new { page }), PagedListRenderOptions.EnableUnobtrusiveAjaxReplacing(new PagedListRenderOptions { MaximumPageNumbersToDisplay = 5, DisplayPageCountAndCurrentLocation = true, UlElementClasses = new[] { "pagination" }, ContainerDivClasses = new[] { "pagination-container" } }, new AjaxOptions() { HttpMethod = "GET", UpdateTargetId = "nameListContainer" }))

--- a/examples/X.PagedList.Mvc.Example.Core/Views/Shared/_Layout.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -31,7 +31,8 @@
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li><a asp-area="" asp-controller="Home" asp-action="Index">Traditional Paging</a></li>                    
+                    <li><a asp-area="" asp-controller="Home" asp-action="Index">Traditional Paging</a></li> 
+                    <li><a asp-area="" asp-controller="Home" asp-action="AjaxIndex">AJAX Paging</a></li> 
                 </ul>
             </div>
         </div>
@@ -47,6 +48,7 @@
     <environment names="Development">
         <script src="~/lib/jquery/dist/jquery.js"></script>
         <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
+        <script src="~/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.js"></script>
         <script src="~/js/site.js" asp-append-version="true"></script>
     </environment>
     <environment names="Staging,Production">
@@ -56,6 +58,7 @@
                 crossorigin="anonymous"
                 integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
         </script>
+        <script src="~/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.min.js"></script>
         <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
                 asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"

--- a/examples/X.PagedList.Mvc.Example.Core/bower.json
+++ b/examples/X.PagedList.Mvc.Example.Core/bower.json
@@ -5,6 +5,7 @@
     "bootstrap": "3.3.7",
     "jquery": "2.2.0",
     "jquery-validation": "1.14.0",
-    "jquery-validation-unobtrusive": "3.2.6"
+    "jquery-validation-unobtrusive": "3.2.6",
+    "jquery-ajax-unobtrusive": "v3.2.4"
   }
 }

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/bootstrap/.bower.json
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/bootstrap/.bower.json
@@ -39,7 +39,6 @@
     "commit": "0b9c4a4007c44201dce9a6cc1a38407005c26c86"
   },
   "_source": "https://github.com/twbs/bootstrap.git",
-  "_target": "v3.3.7",
-  "_originalSource": "bootstrap",
-  "_direct": true
+  "_target": "3.3.7",
+  "_originalSource": "bootstrap"
 }

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/.bower.json
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/.bower.json
@@ -1,0 +1,44 @@
+{
+  "name": "jquery-ajax-unobtrusive",
+  "version": "3.2.4",
+  "homepage": "https://github.com/aspnet/jquery-ajax-unobtrusive",
+  "description": "Add-on to jQuery Ajax to enable unobtrusive options in data-* attributes",
+  "main": [
+    "jquery.unobtrusive-ajax.js"
+  ],
+  "ignore": [
+    "**/.*",
+    "*.json",
+    "*.md",
+    "*.txt",
+    "!LICENSE.txt"
+  ],
+  "keywords": [
+    "jquery",
+    "asp.net",
+    "mvc",
+    "ajax",
+    "unobtrusive"
+  ],
+  "authors": [
+    "Microsoft"
+  ],
+  "license": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/aspnet/jquery-ajax-unobtrusive.git"
+  },
+  "dependencies": {
+    "jquery": ">=1.8"
+  },
+  "_release": "3.2.4",
+  "_resolution": {
+    "type": "version",
+    "tag": "v3.2.4",
+    "commit": "0193de3f75f73b84719bb2c243372f3bc5693462"
+  },
+  "_source": "https://github.com/aspnet/jquery-ajax-unobtrusive.git",
+  "_target": "v3.2.4",
+  "_originalSource": "jquery-ajax-unobtrusive",
+  "_direct": true
+}

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/LICENSE.txt
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/LICENSE.txt
@@ -1,0 +1,12 @@
+Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/bower.json
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/bower.json
@@ -1,0 +1,34 @@
+{
+    "name": "jquery-ajax-unobtrusive",
+    "version": "3.2.4",
+    "homepage": "https://github.com/aspnet/jquery-ajax-unobtrusive",
+    "description": "Add-on to jQuery Ajax to enable unobtrusive options in data-* attributes",
+    "main": [
+        "jquery.unobtrusive-ajax.js"
+    ],
+    "ignore": [
+        "**/.*",
+        "*.json",
+        "*.md",
+        "*.txt",
+        "!LICENSE.txt"
+    ],
+    "keywords": [
+        "jquery",
+        "asp.net",
+        "mvc",
+        "ajax",
+        "unobtrusive"
+    ],
+    "authors": [
+        "Microsoft"
+    ],
+    "license": "https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/aspnet/jquery-ajax-unobtrusive.git"
+    },
+    "dependencies": {
+        "jquery": ">=1.8"
+    }
+}

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/gulpfile.js
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/gulpfile.js
@@ -1,0 +1,12 @@
+var gulp = require("gulp"),
+    uglify = require("gulp-uglify"),
+    rename = require('gulp-rename');
+
+gulp.task("minifyJS", function () {
+    gulp.src(["jquery-ajax-unobtrusive.js"], { base: "." })
+        .pipe(uglify())
+        .pipe(rename({suffix: '.min'}))
+        .pipe(gulp.dest("."));
+});
+
+gulp.task("default", ["minifyJS"]);

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.js
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.js
@@ -1,0 +1,186 @@
+/* 
+ * Microsoft grants you the right to use these script files for the sole
+ * purpose of either: (i) interacting through your browser with the Microsoft
+ * website or online service, subject to the applicable licensing or use
+ * terms; or (ii) using the files as included with a Microsoft product subject
+ * to that product's license terms. Microsoft reserves all other rights to the
+ * files not expressly granted by Microsoft, whether by implication, estoppel
+ * or otherwise. Insofar as a script file is dual licensed under GPL,
+ * Microsoft neither took the code under GPL nor distributes it thereunder but
+ * under the terms set out in this paragraph. All notices and licenses
+ * below are for informational purposes only.
+/*!
+** Unobtrusive Ajax support library for jQuery
+** Copyright (C) Microsoft Corporation. All rights reserved.
+*/
+
+/*jslint white: true, browser: true, onevar: true, undef: true, nomen: true, eqeqeq: true, plusplus: true, bitwise: true, regexp: true, newcap: true, immed: true, strict: false */
+/*global window: false, jQuery: false */
+
+(function ($) {
+    var data_click = "unobtrusiveAjaxClick",
+        data_target = "unobtrusiveAjaxClickTarget",
+        data_validation = "unobtrusiveValidation";
+
+    function getFunction(code, argNames) {
+        var fn = window, parts = (code || "").split(".");
+        while (fn && parts.length) {
+            fn = fn[parts.shift()];
+        }
+        if (typeof (fn) === "function") {
+            return fn;
+        }
+        argNames.push(code);
+        return Function.constructor.apply(null, argNames);
+    }
+
+    function isMethodProxySafe(method) {
+        return method === "GET" || method === "POST";
+    }
+
+    function asyncOnBeforeSend(xhr, method) {
+        if (!isMethodProxySafe(method)) {
+            xhr.setRequestHeader("X-HTTP-Method-Override", method);
+        }
+    }
+
+    function asyncOnSuccess(element, data, contentType) {
+        var mode;
+
+        if (contentType.indexOf("application/x-javascript") !== -1) {  // jQuery already executes JavaScript for us
+            return;
+        }
+
+        mode = (element.getAttribute("data-ajax-mode") || "").toUpperCase();
+        $(element.getAttribute("data-ajax-update")).each(function (i, update) {
+            var top;
+
+            switch (mode) {
+            case "BEFORE":
+                top = update.firstChild;
+                $("<div />").html(data).contents().each(function () {
+                    update.insertBefore(this, top);
+                });
+                break;
+            case "AFTER":
+                $("<div />").html(data).contents().each(function () {
+                    update.appendChild(this);
+                });
+                break;
+            case "REPLACE-WITH":
+                $(update).replaceWith(data);
+                break;
+            default:
+                $(update).html(data);
+                break;
+            }
+        });
+    }
+
+    function asyncRequest(element, options) {
+        var confirm, loading, method, duration;
+
+        confirm = element.getAttribute("data-ajax-confirm");
+        if (confirm && !window.confirm(confirm)) {
+            return;
+        }
+
+        loading = $(element.getAttribute("data-ajax-loading"));
+        duration = parseInt(element.getAttribute("data-ajax-loading-duration"), 10) || 0;
+
+        $.extend(options, {
+            type: element.getAttribute("data-ajax-method") || undefined,
+            url: element.getAttribute("data-ajax-url") || undefined,
+            cache: (element.getAttribute("data-ajax-cache") || "").toLowerCase() === "true",
+            beforeSend: function (xhr) {
+                var result;
+                asyncOnBeforeSend(xhr, method);
+                result = getFunction(element.getAttribute("data-ajax-begin"), ["xhr"]).apply(element, arguments);
+                if (result !== false) {
+                    loading.show(duration);
+                }
+                return result;
+            },
+            complete: function () {
+                loading.hide(duration);
+                getFunction(element.getAttribute("data-ajax-complete"), ["xhr", "status"]).apply(element, arguments);
+            },
+            success: function (data, status, xhr) {
+                asyncOnSuccess(element, data, xhr.getResponseHeader("Content-Type") || "text/html");
+                getFunction(element.getAttribute("data-ajax-success"), ["data", "status", "xhr"]).apply(element, arguments);
+            },
+            error: function () {
+                getFunction(element.getAttribute("data-ajax-failure"), ["xhr", "status", "error"]).apply(element, arguments);
+            }
+        });
+
+        options.data.push({ name: "X-Requested-With", value: "XMLHttpRequest" });
+
+        method = options.type.toUpperCase();
+        if (!isMethodProxySafe(method)) {
+            options.type = "POST";
+            options.data.push({ name: "X-HTTP-Method-Override", value: method });
+        }
+
+        $.ajax(options);
+    }
+
+    function validate(form) {
+        var validationInfo = $(form).data(data_validation);
+        return !validationInfo || !validationInfo.validate || validationInfo.validate();
+    }
+
+    $(document).on("click", "a[data-ajax=true]", function (evt) {
+        evt.preventDefault();
+        asyncRequest(this, {
+            url: this.href,
+            type: "GET",
+            data: []
+        });
+    });
+
+    $(document).on("click", "form[data-ajax=true] input[type=image]", function (evt) {
+        var name = evt.target.name,
+            target = $(evt.target),
+            form = $(target.parents("form")[0]),
+            offset = target.offset();
+
+        form.data(data_click, [
+            { name: name + ".x", value: Math.round(evt.pageX - offset.left) },
+            { name: name + ".y", value: Math.round(evt.pageY - offset.top) }
+        ]);
+
+        setTimeout(function () {
+            form.removeData(data_click);
+        }, 0);
+    });
+
+    $(document).on("click", "form[data-ajax=true] :submit", function (evt) {
+        var name = evt.currentTarget.name,
+            target = $(evt.target),
+            form = $(target.parents("form")[0]);
+
+        form.data(data_click, name ? [{ name: name, value: evt.currentTarget.value }] : []);
+        form.data(data_target, target);
+
+        setTimeout(function () {
+            form.removeData(data_click);
+            form.removeData(data_target);
+        }, 0);
+    });
+
+    $(document).on("submit", "form[data-ajax=true]", function (evt) {
+        var clickInfo = $(this).data(data_click) || [],
+            clickTarget = $(this).data(data_target),
+            isCancel = clickTarget && clickTarget.hasClass("cancel");
+        evt.preventDefault();
+        if (!isCancel && !validate(this)) {
+            return;
+        }
+        asyncRequest(this, {
+            url: this.action,
+            type: this.method || "GET",
+            data: clickInfo.concat($(this).serializeArray())
+        });
+    });
+}(jQuery));

--- a/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.min.js
+++ b/examples/X.PagedList.Mvc.Example.Core/wwwroot/lib/jquery-ajax-unobtrusive/jquery.unobtrusive-ajax.min.js
@@ -1,0 +1,19 @@
+/* NUGET: BEGIN LICENSE TEXT
+ *
+ * Microsoft grants you the right to use these script files for the sole
+ * purpose of either: (i) interacting through your browser with the Microsoft
+ * website or online service, subject to the applicable licensing or use
+ * terms; or (ii) using the files as included with a Microsoft product subject
+ * to that product's license terms. Microsoft reserves all other rights to the
+ * files not expressly granted by Microsoft, whether by implication, estoppel
+ * or otherwise. Insofar as a script file is dual licensed under GPL,
+ * Microsoft neither took the code under GPL nor distributes it thereunder but
+ * under the terms set out in this paragraph. All notices and licenses
+ * below are for informational purposes only.
+ *
+ * NUGET: END LICENSE TEXT */
+/*
+** Unobtrusive Ajax support library for jQuery
+** Copyright (C) Microsoft Corporation. All rights reserved.
+*/
+(function(a){var b="unobtrusiveAjaxClick",d="unobtrusiveAjaxClickTarget",h="unobtrusiveValidation";function c(d,b){var a=window,c=(d||"").split(".");while(a&&c.length)a=a[c.shift()];if(typeof a==="function")return a;b.push(d);return Function.constructor.apply(null,b)}function e(a){return a==="GET"||a==="POST"}function g(b,a){!e(a)&&b.setRequestHeader("X-HTTP-Method-Override",a)}function i(c,b,e){var d;if(e.indexOf("application/x-javascript")!==-1)return;d=(c.getAttribute("data-ajax-mode")||"").toUpperCase();a(c.getAttribute("data-ajax-update")).each(function(f,c){var e;switch(d){case"BEFORE":e=c.firstChild;a("<div />").html(b).contents().each(function(){c.insertBefore(this,e)});break;case"AFTER":a("<div />").html(b).contents().each(function(){c.appendChild(this)});break;case"REPLACE-WITH":a(c).replaceWith(b);break;default:a(c).html(b)}})}function f(b,d){var j,k,f,h;j=b.getAttribute("data-ajax-confirm");if(j&&!window.confirm(j))return;k=a(b.getAttribute("data-ajax-loading"));h=parseInt(b.getAttribute("data-ajax-loading-duration"),10)||0;a.extend(d,{type:b.getAttribute("data-ajax-method")||undefined,url:b.getAttribute("data-ajax-url")||undefined,cache:(b.getAttribute("data-ajax-cache")||"").toLowerCase()==="true",beforeSend:function(d){var a;g(d,f);a=c(b.getAttribute("data-ajax-begin"),["xhr"]).apply(b,arguments);a!==false&&k.show(h);return a},complete:function(){k.hide(h);c(b.getAttribute("data-ajax-complete"),["xhr","status"]).apply(b,arguments)},success:function(a,e,d){i(b,a,d.getResponseHeader("Content-Type")||"text/html");c(b.getAttribute("data-ajax-success"),["data","status","xhr"]).apply(b,arguments)},error:function(){c(b.getAttribute("data-ajax-failure"),["xhr","status","error"]).apply(b,arguments)}});d.data.push({name:"X-Requested-With",value:"XMLHttpRequest"});f=d.type.toUpperCase();if(!e(f)){d.type="POST";d.data.push({name:"X-HTTP-Method-Override",value:f})}a.ajax(d)}function j(c){var b=a(c).data(h);return!b||!b.validate||b.validate()}a(document).on("click","a[data-ajax=true]",function(a){a.preventDefault();f(this,{url:this.href,type:"GET",data:[]})});a(document).on("click","form[data-ajax=true] input[type=image]",function(c){var g=c.target.name,e=a(c.target),f=a(e.parents("form")[0]),d=e.offset();f.data(b,[{name:g+".x",value:Math.round(c.pageX-d.left)},{name:g+".y",value:Math.round(c.pageY-d.top)}]);setTimeout(function(){f.removeData(b)},0)});a(document).on("click","form[data-ajax=true] :submit",function(e){var g=e.currentTarget.name,f=a(e.target),c=a(f.parents("form")[0]);c.data(b,g?[{name:g,value:e.currentTarget.value}]:[]);c.data(d,f);setTimeout(function(){c.removeData(b);c.removeData(d)},0)});a(document).on("submit","form[data-ajax=true]",function(h){var e=a(this).data(b)||[],c=a(this).data(d),g=c&&c.hasClass("cancel");h.preventDefault();if(!g&&!j(this))return;f(this,{url:this.action,type:this.method||"GET",data:e.concat(a(this).serializeArray())})})})(jQuery);

--- a/src/X.PagedList.Mvc.Core/Fake/AjaxOptions.cs
+++ b/src/X.PagedList.Mvc.Core/Fake/AjaxOptions.cs
@@ -8,6 +8,11 @@ namespace X.PagedList.Mvc.Core.Fake
         {
             var result = new List<HtmlAttribute>();
 
+            result.Add(new HtmlAttribute() { Key = "data-ajax-method", Value = this.HttpMethod });
+            result.Add(new HtmlAttribute() { Key = "data-ajax-mode", Value = this.InsertionMode });
+            result.Add(new HtmlAttribute() { Key = "data-ajax-update", Value = "#" + this.UpdateTargetId });
+            result.Add(new HtmlAttribute() { Key = "data-ajax", Value = "true" });
+
             return result;
         }
 

--- a/src/X.PagedList.Mvc.Core/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlHelper.cs
@@ -46,7 +46,7 @@ namespace X.PagedList.Mvc.Core
                 li.AddCssClass(@class);
             if (options.FunctionToTransformEachPageLink != null)
             {
-                return options.FunctionToTransformEachPageLink(li, inner);
+                inner = options.FunctionToTransformEachPageLink(li, inner);
             }
 
             AppendHtml(li, TagBuilderToString(inner));

--- a/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
@@ -258,9 +258,7 @@ namespace X.PagedList.Mvc.Core
                                                                   foreach (var ajaxOption in ajaxOptions.ToUnobtrusiveHtmlAttributes())
                                                                       aTagBuilder.Attributes.Add(ajaxOption.Key, ajaxOption.Value.ToString());
                                                               }
-
-                                                              liTagBuilder.InnerHtml.SetContent(aTagBuilder.ToString());
-                                                              return liTagBuilder;
+                                                              return aTagBuilder;
                                                           };
             return options;
         }


### PR DESCRIPTION
I added an index view so the .net core example worked.  Modified the fake AjaxOptions and pagedlist renderer so it was correctly inserting the inner html for li elements with the data-ajax attributes. Added very basic .net core ajax paging example. 