### PR TITLE
Build with multiple .net versions

### DIFF
--- a/src/X.PagedList.Mvc/X.PagedList.Mvc.csproj
+++ b/src/X.PagedList.Mvc/X.PagedList.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;net461</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>7.2.2</Version>
     <Authors>Copyright Troy Goode, Ernado © 2017</Authors>

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.2</TargetFramework>
+    <TargetFrameworks>netstandard1.2;net452;net461</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Copyright Troy Goode, Ernado © 2017</Authors>
     <Company>.NET Core Ukrainian User Group</Company>


### PR DESCRIPTION
Build against multiple .Net targets so that users on .Net Framework don't have to include a **lot** of .Net Standard packages in their solutions. Fixes #92.