### PR TITLE
Added OnComplete property missing in AjaxOptions class

### DIFF
--- a/src/X.PagedList.Mvc.Core/AjaxOptions.cs
+++ b/src/X.PagedList.Mvc.Core/AjaxOptions.cs
@@ -4,20 +4,22 @@ namespace X.PagedList.Mvc.Core
 {
     public class AjaxOptions
     {
-        public IEnumerable<HtmlAttribute> ToUnobtrusiveHtmlAttributes()
+        public virtual IEnumerable<HtmlAttribute> ToUnobtrusiveHtmlAttributes()
         {
             return new List<HtmlAttribute>
             {
                 new HtmlAttribute {Key = "data-ajax-method", Value = HttpMethod},
                 new HtmlAttribute {Key = "data-ajax-mode", Value = InsertionMode},
                 new HtmlAttribute {Key = "data-ajax-update", Value = "#" + UpdateTargetId},
-                new HtmlAttribute {Key = "data-ajax", Value = "true"}
+                new HtmlAttribute {Key = "data-ajax", Value = "true"},
+                new HtmlAttribute {Key = "data-ajax-complete", Value = OnComplete}
             };
         }
 
         public string HttpMethod { get; set; }
         public InsertionMode InsertionMode { get; set; }
         public string UpdateTargetId { get; set; }
+        public string OnComplete { get; set; }
     }
 
     public enum InsertionMode


### PR DESCRIPTION
I have created Issue 102.
Here is implementation on `OnComplete` for ajax paging with MVC.Core.
Also I have made ToUnobtrusiveHtmlAttributes virtual, so maybe later somebody wants to inherit `AjaxOptions` class and implement other properties also.