### PR TITLE
Paged List Select extension method is now an extension of IPagedList. fixes #112

### DIFF
--- a/src/X.PagedList/PagedListExtensions.cs
+++ b/src/X.PagedList/PagedListExtensions.cs
@@ -98,7 +98,7 @@ namespace X.PagedList
         /// <typeparam name="TSource">Input Type</typeparam>
         /// <typeparam name="TResult">Result Type</typeparam>
         /// <returns>New PagedList</returns>
-        public static IPagedList<TResult> Select<TSource, TResult>(this PagedList<TSource> source, Func<TSource, TResult> selector)
+        public static IPagedList<TResult> Select<TSource, TResult>(this IPagedList<TSource> source, Func<TSource, TResult> selector)
         {
             var subset = ((IEnumerable<TSource>)source).Select(selector);
             return new PagedList<TResult>(source, subset);


### PR DESCRIPTION
Paged List Select extension method is now an extension of `IPagedList` rather than `PagedList`.

As `PagedList` implements `IPagedList` there should be no issues.

Use case for change described in #112 