### PR TITLE
Bug 169: Fix exception with pageNumber greater than 1

### DIFF
--- a/X.PagedList.sln
+++ b/X.PagedList.sln
@@ -23,7 +23,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X.PagedList.Mvc.Example.Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X.PagedList.Web.Common", "src\X.PagedList.Web.Common\X.PagedList.Web.Common.csproj", "{A83A2188-D9AB-4A53-9888-D00EBCAC5160}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "X.PagedList.EF", "src\X.PagedList.EF\X.PagedList.EF.csproj", "{5D72EF31-35AD-4FB6-987A-5644B8CFD918}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X.PagedList.EF", "src\X.PagedList.EF\X.PagedList.EF.csproj", "{5D72EF31-35AD-4FB6-987A-5644B8CFD918}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "X.PagedList.EF.Tests", "tests\X.PagedList.EF.Tests\X.PagedList.EF.Tests.csproj", "{75367B5D-FB8B-4B1C-884C-DB52B316EB7C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{5D72EF31-35AD-4FB6-987A-5644B8CFD918}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5D72EF31-35AD-4FB6-987A-5644B8CFD918}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5D72EF31-35AD-4FB6-987A-5644B8CFD918}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75367B5D-FB8B-4B1C-884C-DB52B316EB7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75367B5D-FB8B-4B1C-884C-DB52B316EB7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75367B5D-FB8B-4B1C-884C-DB52B316EB7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75367B5D-FB8B-4B1C-884C-DB52B316EB7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -76,6 +82,7 @@ Global
 		{89EA823D-1A1B-4569-B33B-A54CEFAFE480} = {309A8FC8-4784-4D8D-903F-BD54EBB0F1D7}
 		{A83A2188-D9AB-4A53-9888-D00EBCAC5160} = {BDDADD09-D112-418E-8469-BC762EC09936}
 		{5D72EF31-35AD-4FB6-987A-5644B8CFD918} = {BDDADD09-D112-418E-8469-BC762EC09936}
+		{75367B5D-FB8B-4B1C-884C-DB52B316EB7C} = {0170B742-C624-4C22-9DE1-2A93CF9C12D6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1A82D446-6F26-48B2-8085-DFA5F87453FC}

--- a/src/X.PagedList.EF/PagedList.cs
+++ b/src/X.PagedList.EF/PagedList.cs
@@ -38,10 +38,12 @@ namespace X.PagedList.EF
 
 		private void InitSubset(IQueryable<T> superset, Func<T, TKey> keySelectorMethod, int pageNumber, int pageSize)
         {
+            var itemsToSkip = (pageNumber - 1) * pageSize;
+
             // add items to internal list
             var items = pageNumber == 1
-				? superset.OrderBy(keySelectorMethod).AsQueryable().Take(() => pageSize).ToList()
-				: superset.OrderBy(keySelectorMethod).AsQueryable().Skip(() => (pageNumber - 1) * pageSize).Take(() => pageSize).ToList();
+                ? superset.OrderBy(keySelectorMethod).AsQueryable().Take(() => pageSize).ToList()
+                : superset.OrderBy(keySelectorMethod).AsQueryable().Skip(() => itemsToSkip).Take(() => pageSize).ToList();
 
 			Subset.AddRange(items);
 		}
@@ -76,10 +78,12 @@ namespace X.PagedList.EF
 
                 superset = superset ?? new List<T>().AsQueryable();
 
+                int itemsToSkip = (pageNumber - 1) * pageSize;
+
                 Subset.AddRange(pageNumber == 1
-					? superset.Take(() => pageSize).ToList()
-					: superset.Skip(() => (pageNumber - 1) * pageSize).Take(() => pageSize).ToList()
-				);
+                    ? superset.Take(() => pageSize).ToList()
+                    : superset.Skip(() => itemsToSkip).Take(() => pageSize).ToList()
+                );
 			}
 		}
 

--- a/tests/X.PagedList.EF.Tests/App.config
+++ b/tests/X.PagedList.EF.Tests/App.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+</configuration>

--- a/tests/X.PagedList.EF.Tests/Blog.cs
+++ b/tests/X.PagedList.EF.Tests/Blog.cs
@@ -1,0 +1,9 @@
+﻿namespace X.PagedList.EF.Tests
+{
+    class Blog
+    {
+        public int BlogId { get; set; }
+        public string Name { get; set; }
+        public string Url { get; set;  }
+    }
+}

--- a/tests/X.PagedList.EF.Tests/PagedListTheories.cs
+++ b/tests/X.PagedList.EF.Tests/PagedListTheories.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace X.PagedList.EF.Tests
+{
+    public class PagedListTheories
+    {
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void EFPagedList_With_IOrderedQueryable_Works(int pageNumber, int pageSize)
+        {
+            using (var db = new TestContext())
+            {
+                // arrange 
+                var blogsQuery = db.Blogs;
+                var orderedBlogsQuery = db.Blogs.OrderBy(b => b.BlogId);
+
+                // act
+                var blogs = new PagedList<Blog>(orderedBlogsQuery, pageNumber, pageSize);
+
+                // assert
+                Assert.Equal(pageNumber, blogs.PageNumber);
+                Assert.Equal(pageSize, blogs.PageSize);
+                Assert.Equal(pageNumber, blogs[0].BlogId);
+            }
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void EFPagedList_With_KeySelector_Works(int pageNumber, int pageSize)
+        {
+            using (var db = new TestContext())
+            {
+                // arrange 
+                var blogsQuery = db.Blogs;
+                Expression<Func<Blog, int>> keySelector = b => b.BlogId;
+
+                // act
+                var blogs = new PagedList<Blog, int>(blogsQuery, keySelector, pageNumber, pageSize);
+
+                // assert
+                Assert.Equal(pageNumber, blogs.PageNumber);
+                Assert.Equal(pageSize, blogs.PageSize);
+                Assert.Equal(pageNumber, blogs[0].BlogId);
+            }
+        }
+    }
+}

--- a/tests/X.PagedList.EF.Tests/TestContext.cs
+++ b/tests/X.PagedList.EF.Tests/TestContext.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Text;
+
+namespace X.PagedList.EF.Tests
+{
+    class TestContext: DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+
+        public TestContext()
+        {
+            Database.SetInitializer(new TestContextDBInitializer());
+        }
+
+    }
+
+    class TestContextDBInitializer : DropCreateDatabaseAlways<TestContext>
+    {
+        protected override void Seed(TestContext context)
+        {
+            // Create a couple of blog entries.
+            IList<Blog> defaultBlogs = new List<Blog>();
+            for (int i = 1; i <= 10; i++)
+            {
+                defaultBlogs.Add(new Blog() {BlogId = i, Name = $"Blog {i}", Url = $"http://blogs.com/{i}"});
+            }
+
+            context.Blogs.AddRange(defaultBlogs);
+
+            base.Seed(context);
+        }
+    }
+
+    class Blog
+    {
+        public int BlogId { get; set; }
+        public string Name { get; set; }
+        public string Url { get; set;  }
+    }
+}

--- a/tests/X.PagedList.EF.Tests/TestContext.cs
+++ b/tests/X.PagedList.EF.Tests/TestContext.cs
@@ -13,30 +13,5 @@ namespace X.PagedList.EF.Tests
         {
             Database.SetInitializer(new TestContextDBInitializer());
         }
-
-    }
-
-    class TestContextDBInitializer : DropCreateDatabaseAlways<TestContext>
-    {
-        protected override void Seed(TestContext context)
-        {
-            // Create a couple of blog entries.
-            IList<Blog> defaultBlogs = new List<Blog>();
-            for (int i = 1; i <= 10; i++)
-            {
-                defaultBlogs.Add(new Blog() {BlogId = i, Name = $"Blog {i}", Url = $"http://blogs.com/{i}"});
-            }
-
-            context.Blogs.AddRange(defaultBlogs);
-
-            base.Seed(context);
-        }
-    }
-
-    class Blog
-    {
-        public int BlogId { get; set; }
-        public string Name { get; set; }
-        public string Url { get; set;  }
     }
 }

--- a/tests/X.PagedList.EF.Tests/TestContextDBInitializer.cs
+++ b/tests/X.PagedList.EF.Tests/TestContextDBInitializer.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Data.Entity;
+
+namespace X.PagedList.EF.Tests
+{
+    class TestContextDBInitializer : DropCreateDatabaseAlways<TestContext>
+    {
+        protected override void Seed(TestContext context)
+        {
+            // Create a couple of blog entries.
+            IList<Blog> defaultBlogs = new List<Blog>();
+            for (int i = 1; i <= 10; i++)
+            {
+                defaultBlogs.Add(new Blog() {BlogId = i, Name = $"Blog {i}", Url = $"http://blogs.com/{i}"});
+            }
+
+            context.Blogs.AddRange(defaultBlogs);
+
+            base.Seed(context);
+        }
+    }
+}

--- a/tests/X.PagedList.EF.Tests/X.PagedList.EF.Tests.csproj
+++ b/tests/X.PagedList.EF.Tests/X.PagedList.EF.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\X.PagedList.EF\X.PagedList.EF.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Declare a variable 'itemsToSkip' that is calculated upfront and use that variable instead of the calculation in the Skip method.

The argument passed to the Skip method then is a DbParameterReferenceExpression so the exception does not occur anymore.