### PR TITLE
Change X.PagedList.Mvc and X.PagedList.EF target framework to net461

### DIFF
--- a/src/X.PagedList.EF/X.PagedList.EF.csproj
+++ b/src/X.PagedList.EF/X.PagedList.EF.csproj
@@ -14,7 +14,6 @@
     <AssemblyVersion>8.0.7</AssemblyVersion>
     <FileVersion>8.0.7</FileVersion>
     <TargetFramework>net461</TargetFramework>
-    <LangVersion>8</LangVersion>
     <PackageVersion>8.0.7</PackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>xpagedlist.snk</AssemblyOriginatorKeyFile>

--- a/src/X.PagedList.EF/X.PagedList.EF.csproj
+++ b/src/X.PagedList.EF/X.PagedList.EF.csproj
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <AssemblyVersion>8.0.7</AssemblyVersion>
     <FileVersion>8.0.7</FileVersion>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <LangVersion>8</LangVersion>
     <PackageVersion>8.0.7</PackageVersion>
     <SignAssembly>true</SignAssembly>

--- a/src/X.PagedList.Mvc/X.PagedList.Mvc.csproj
+++ b/src/X.PagedList.Mvc/X.PagedList.Mvc.csproj
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <AssemblyVersion>8.0.7</AssemblyVersion>
     <FileVersion>8.0.7</FileVersion>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>xpagedlist.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/X.PagedList.Web.Common/X.PagedList.Web.Common.csproj
+++ b/src/X.PagedList.Web.Common/X.PagedList.Web.Common.csproj
@@ -13,7 +13,7 @@
     <FileVersion>8.0.7</FileVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dncuug/X.PagedList.git</RepositoryUrl>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>xpagedlist.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/dncuug/X.PagedList.git</RepositoryUrl>
     <Description>Library for easily paging through any IEnumerable/IQueryable in .NET and .NET Core</Description>
     <PackageIconUrl>https://ru.gravatar.com/userimage/8071071/f2dc08ee7e4016451f64a7ae9cffd110.png?size=200</PackageIconUrl>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>xpagedlist.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
This changes the required .NET Framework version from 4.8 to 4.6.1, so more projects can use these packages (upgrading the project framework is not always possible): this fixes https://github.com/dncuug/X.PagedList/issues/190.