### PR TITLE
Fix List Render when using Ajax Options

### DIFF
--- a/examples/X.PagedList.Mvc.Example.Core/Views/Bootstrap41/AjaxIndex.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Bootstrap41/AjaxIndex.cshtml
@@ -2,10 +2,9 @@
     ViewBag.Title = "Product Listing";
 }
 
-@using X.PagedList; @*import this so we can cast our list to IPagedList (only necessary because ViewBag is dynamic)*@
 
 <!-- loop through each of your products and display it however you want. we're just printing the name here -->
 <h2>List of Products</h2>
 <div id="nameListContainer">
-    @Html.Partial("_NameListPartial", (IPagedList<string>)ViewBag.Names)
+    <partial name="_NameListPartial" model="ViewBag.Names" />
 </div>

--- a/examples/X.PagedList.Mvc.Example.Core/Views/Home/AjaxIndex.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Home/AjaxIndex.cshtml
@@ -2,10 +2,9 @@
     ViewBag.Title = "Product Listing";
 }
 
-@using X.PagedList; @*import this so we can cast our list to IPagedList (only necessary because ViewBag is dynamic)*@
 
 <!-- loop through each of your products and display it however you want. we're just printing the name here -->
 <h2>List of Products</h2>
 <div id="nameListContainer">
-    @Html.Partial("_NameListPartial", (IPagedList<string>)ViewBag.Names)
+    <partial name="_NameListPartial" model="ViewBag.Names" />
 </div>

--- a/src/X.PagedList.Mvc.Core/Common/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/Common/PagedListRenderOptions.cs
@@ -387,7 +387,7 @@
                         }
                     }
 
-                    liTagBuilder.AppendHtml(aTagBuilder.ToString());
+                    liTagBuilder.AppendHtml(aTagBuilder.ToString(TagRenderMode.Normal));
 
                     return liTagBuilder;
                 };

--- a/src/X.PagedList.Mvc.Core/X.PagedList.Mvc.Core.csproj
+++ b/src/X.PagedList.Mvc.Core/X.PagedList.Mvc.Core.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\X.PagedList.Web.Common\X.PagedList.Web.Common.csproj" />
     <ProjectReference Include="..\X.PagedList\X.PagedList.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
In the EnableUnobtrusiveAjaxReplacing method I found that the aTagBuilder.ToString is not using the proper overload