### PR TITLE
Added ItemSliceAndTotalPosition option to control place of this item

### DIFF
--- a/examples/X.PagedList.Mvc.Example.Core/Views/Home/Index.cshtml
+++ b/examples/X.PagedList.Mvc.Example.Core/Views/Home/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@{
     ViewBag.Title = "Product Listing";
-    var pagedList = (IPagedList) ViewBag.Names;
+    var pagedList = (IPagedList)ViewBag.Names;
 }
 
 @using X.PagedList.Mvc.Core; @*import this so we get our HTML Helper*@
@@ -39,3 +39,22 @@
     .DisplayLinkToNextPage()
     .MaximumPageNumbersToDisplay(3)
     .Build())
+
+<h3>Pager with ItemSliceAndTotalPosition at the end</h3>
+@Html.PagedListPager(pagedList,
+    page => Url.Action("Index",
+        new { page }),
+        new PagedListRenderOptions()
+        {
+            DisplayItemSliceAndTotal = true,
+            ItemSliceAndTotalPosition = ItemSliceAndTotalPosition.End
+        })
+
+<h3>Pager with ItemSliceAndTotalPosition at the beginning</h3>
+@Html.PagedListPager(pagedList,
+    page => Url.Action("Index",
+        new { page }),
+    new PagedListRenderOptions()
+    {
+        DisplayItemSliceAndTotal = true,
+    })

--- a/src/X.PagedList.Mvc.Core/Common/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc.Core/Common/HtmlHelper.cs
@@ -326,7 +326,7 @@ namespace X.PagedList.Web.Common
             }
 
             //text
-            if (options.DisplayItemSliceAndTotal)
+            if (options.DisplayItemSliceAndTotal && options.ItemSliceAndTotalPosition == ItemSliceAndTotalPosition.Start)
             {
                 listItemLinks.Add(ItemSliceAndTotalText(list, options));
             }
@@ -372,6 +372,12 @@ namespace X.PagedList.Web.Common
                 (options.DisplayLinkToLastPage == PagedListDisplayMode.IfNeeded && lastPageToDisplay < list.PageCount))
             {
                 listItemLinks.Add(Last(list, generatePageUrl, options));
+            }
+
+            //text
+            if (options.DisplayItemSliceAndTotal && options.ItemSliceAndTotalPosition == ItemSliceAndTotalPosition.End)
+            {
+                listItemLinks.Add(ItemSliceAndTotalText(list, options));
             }
 
             if (listItemLinks.Any())

--- a/src/X.PagedList.Mvc.Core/Common/ItemSliceAndTotalPosition.cs
+++ b/src/X.PagedList.Mvc.Core/Common/ItemSliceAndTotalPosition.cs
@@ -1,0 +1,18 @@
+﻿namespace X.PagedList.Web.Common
+{
+    /// <summary>
+    /// A two-state enum that controls the position of ItemSliceAndTotal text within PagedList items.
+    /// </summary>
+    public enum ItemSliceAndTotalPosition
+    {
+        /// <summary>
+        /// Shows ItemSliceAndTotal info at the beginning of the PagedList items.
+        /// </summary>
+        Start,
+
+        /// <summary>
+        /// Shows ItemSliceAndTotal info at the end of the PagedList items.
+        /// </summary>
+        End
+    }
+}

--- a/src/X.PagedList.Mvc.Core/Common/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/Common/PagedListRenderOptions.cs
@@ -29,6 +29,7 @@
             LinkToLastPageFormat = ">>";
             PageCountAndCurrentLocationFormat = "Page {0} of {1}.";
             ItemSliceAndTotalFormat = "Showing items {0} through {1} of {2}.";
+            ItemSliceAndTotalPosition = ItemSliceAndTotalPosition.Start;
             FunctionToDisplayEachPageNumber = null;
             ClassToApplyToFirstListItemInPager = null;
             ClassToApplyToLastListItemInPager = null;
@@ -227,6 +228,11 @@
         /// "Showing items {0} through {1} of {2}."
         ///</example>
         public string ItemSliceAndTotalFormat { get; set; }
+
+        /// <summary>
+        /// If set to <see cref="ItemSliceAndTotalPosition.Start"/>, render an info at the beginning of the list. If set to <see cref="ItemSliceAndTotalPosition.End"/>, render the at the beginning of the list.
+        /// </summary>
+        public ItemSliceAndTotalPosition ItemSliceAndTotalPosition { get; set; }
 
         /// <summary>
         /// A function that will render each page number when specified (and DisplayLinkToIndividualPages is true). If no function is specified, the LinkToIndividualPageFormat value will be used instead.

--- a/src/X.PagedList.Mvc.Core/X.PagedList.Mvc.Core.csproj
+++ b/src/X.PagedList.Mvc.Core/X.PagedList.Mvc.Core.csproj
@@ -9,9 +9,9 @@
     <PackageIconUrl>https://ru.gravatar.com/userimage/8071071/f2dc08ee7e4016451f64a7ae9cffd110.png?size=200</PackageIconUrl>
     <RepositoryUrl>https://github.com/dncuug/X.PagedList.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>8.1.0</Version>
-    <AssemblyVersion>8.1.0</AssemblyVersion>
-    <FileVersion>8.1.0</FileVersion>
+    <Version>8.3.0</Version>
+    <AssemblyVersion>8.3.0</AssemblyVersion>
+    <FileVersion>8.3.0</FileVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dncuug/X.PagedList.git</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -4,9 +4,9 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Copyright Troy Goode, Ernado © 2021</Authors>
     <Company>Ukrainian .NET Developer Community</Company>
-    <Version>8.1.0</Version>
-    <AssemblyVersion>8.1.0</AssemblyVersion>
-    <FileVersion>8.1.0</FileVersion>
+    <Version>8.2.0</Version>
+    <AssemblyVersion>8.2.0</AssemblyVersion>
+    <FileVersion>8.2.0</FileVersion>
     <PackageProjectUrl>https://github.com/dncuug/X.PagedList</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/dncuug/X.PagedList/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Added option `ItemSliceAndTotalPosition` to place an ItemSliceAndTotalPosition info at the beginning or the end of PagedList items.

Default behavior of the PageList is not changed.