### PR TITLE
X.PagedList.Mvc.Core: Revert behavior for UpdateTargetId

### DIFF
--- a/src/X.PagedList.Mvc.Core/AjaxOptions.cs
+++ b/src/X.PagedList.Mvc.Core/AjaxOptions.cs
@@ -8,10 +8,10 @@ public class AjaxOptions
     {
         var attrs = new List<HtmlAttribute>
         {
-            new() { Key = "data-ajax-method", Value = HttpMethod },
-            new() { Key = "data-ajax-mode", Value = InsertionMode },
-            new() { Key = "data-ajax-update", Value = UpdateTargetId },
-            new() { Key = "data-ajax", Value = "true" }
+            new() {Key = "data-ajax-method", Value = HttpMethod},
+            new() {Key = "data-ajax-mode", Value = InsertionMode},
+            new() {Key = "data-ajax-update", Value = "#" + UpdateTargetId},
+            new() {Key = "data-ajax", Value = "true"}
         };
 
         if (!string.IsNullOrEmpty(Confirm))

--- a/src/X.PagedList.Mvc.Core/README.md
+++ b/src/X.PagedList.Mvc.Core/README.md
@@ -6,7 +6,6 @@
 Library was not updated for a long time. This version contains lot of breaking changes:
 - Updated namespaces
 - Removed some classes which duplicated ASP.NET Core classes
-- UpdateTargetId in AjaxOptions now not automatically prepended
 - Other changes
 
 ## What is this?


### PR DESCRIPTION
This reverts commit 01d9633478dcd06e267d466e71145d030cdb5ffa.

In [1], behavior for the UpdateTargetId was changed so the "#" symbol is not prepended anymore and one has to add it manually now. However, the very name "UpdateTargetId" indicates that this is an ID and not something else. Similar behavior is found for JavaScript, where a function name containing "Id" implies that the hash symbol is not required.

Revert this to the previous behavior (<= 8.4.7), so it can be used without changes coming from any version except 9.1.2. This implements the correct behavior as it implies the provided value is actually an ID.

Future alternate solutions as discussed in #245 might choose different names to accept arbitrary elements as argument (e.g. UpdateTarget to accept IDs, classes, etc.).

Note that examples never got updated anyway (and thus no need to revert them).

[1] 01d9633478dc ("Close #221")

Fixes: #245