### PR TITLE
X.PagedList: PagedListExtensions: Fix logic in ToPagedList()

### DIFF
--- a/src/X.PagedList/PagedListExtensions.cs
+++ b/src/X.PagedList/PagedListExtensions.cs
@@ -100,7 +100,7 @@ public static class PagedListExtensions
     /// <param name="superset">
     /// The collection of objects to be divided into subsets. If the
     /// collection implements <see cref="IQueryable{T}"/>, it will be treated as such.
-    /// </param>       
+    /// </param>
     /// <returns>A subset of this collection of objects that can be individually accessed by index and containing
     /// metadata about the collection of objects the subset was created from.</returns>
     /// <seealso cref="PagedList{T}"/>
@@ -159,7 +159,7 @@ public static class PagedListExtensions
     /// <returns>
     /// A subset of this collection of objects that can be individually accessed by index and containing metadata
     /// about the collection of objects the subset was created from.
-    /// </returns>        
+    /// </returns>
     public static IPagedList<T> ToPagedList<T, TKey>(this IEnumerable<T> superset, Expression<Func<T, TKey>> keySelector, int pageNumber, int pageSize)
     {
         if (superset == null)
@@ -204,26 +204,19 @@ public static class PagedListExtensions
             throw new ArgumentOutOfRangeException($"pageSize = {pageSize}. PageSize cannot be less than 1.");
         }
 
-        var supersetCount = superset.Count();
-
-        if (supersetCount > totalSetCount)
-        {
-            throw new ArgumentOutOfRangeException($"superset count = {supersetCount} superset count cannot be more than {totalSetCount.Value}.");
-        }
+        int totalCount = totalSetCount ?? superset.Count();
 
         List<T> subset;
 
-        var totalCount = totalSetCount ?? supersetCount;
-
-        if ((totalCount <= 0 || totalSetCount.HasValue) && supersetCount <= pageSize)
-        {
-            subset = superset.ToList();
-        }
-        else
+        if (totalCount > 0)
         {
             var skip = (pageNumber - 1) * pageSize;
 
             subset = superset.Skip(skip).Take(pageSize).ToList();
+        }
+        else
+        {
+            subset = new List<T>();
         }
 
         return new StaticPagedList<T>(subset, pageNumber, pageSize, totalCount);

--- a/tests/X.PagedList.Tests/PagedListTheories.cs
+++ b/tests/X.PagedList.Tests/PagedListTheories.cs
@@ -49,7 +49,7 @@ public class PagedListTheories
         var superset = BuildBlogList(1000);
 
         var pageOfSuperSet = superset.Skip(listPageNumber * pageSize).Take(pageSize).ToList();
-        var pagedBlogs = await pageOfSuperSet.AsQueryable().ToPagedListAsync(xListPageNumber, pageSize, superSetTotalCount);
+        var pagedBlogs = await superset.AsQueryable().ToPagedListAsync(xListPageNumber, pageSize, superSetTotalCount);
         var pagedBlogsWithoutTotalCount = await superset.AsQueryable().ToPagedListAsync(xListPageNumber, pageSize);
 
         //test the totalSetCount extension


### PR DESCRIPTION
The command flow in ToPagedList with totalSetCount appears odd:

  * For totalCount <= 0, we should simply return an empty list

  * For supersetCount <= pageSize, we should not need additional conditions to simply read the list

  * From totalSetCount.HasValue, we know whether to use Count(), but not whether or not to use Skip/Take

  * Count() is always executed, even if we supply totalSetCount, which will create useless iterations and/or DB roundtrips if we already know the size.

As a consequence, it appears more appropriate to use the logic from X.PagedList.EF here as well (only in the sync version), which addresses all the mentioned issues.

Fixes: #266