### PR TITLE
Enable nullable annotations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,8 @@
         <AssemblyOriginatorKeyFile>xpagedlist.snk</AssemblyOriginatorKeyFile>
 
         <PackageVersion>9.1.2</PackageVersion>
+
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/X.PagedList.EF/PagedListExtensions.cs
+++ b/src/X.PagedList.EF/PagedListExtensions.cs
@@ -60,7 +60,7 @@ public static class PagedListExtensions
 
         if (totalCount > 0)
         {
-            var skip = (pageNumber - 1) * pageSize;
+            int skip = (pageNumber - 1) * pageSize;
 
             subset = await superset.Skip(skip).Take(pageSize).ToListAsync(cancellationToken).ConfigureAwait(false);
         }

--- a/src/X.PagedList.EF/X.PagedList.EF.csproj
+++ b/src/X.PagedList.EF/X.PagedList.EF.csproj
@@ -5,8 +5,6 @@
 
         <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
         <LangVersion>default</LangVersion>
-
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/X.PagedList.Mvc.Core/AjaxOptions.cs
+++ b/src/X.PagedList.Mvc.Core/AjaxOptions.cs
@@ -62,8 +62,8 @@ public class AjaxOptions
         return attrs;
     }
 
-    public string HttpMethod { get; set; }
-    public InsertionMode InsertionMode { get; set; }
+    public string HttpMethod { get; set; } = "GET";
+    public InsertionMode InsertionMode { get; set; } = InsertionMode.Replace;
     public string? UpdateTargetId { get; set; }
     public string? Confirm { get; set; }
     public int LoadingElementDuration { get; set; }

--- a/src/X.PagedList.Mvc.Core/AjaxOptions.cs
+++ b/src/X.PagedList.Mvc.Core/AjaxOptions.cs
@@ -64,15 +64,15 @@ public class AjaxOptions
 
     public string HttpMethod { get; set; }
     public InsertionMode InsertionMode { get; set; }
-    public string UpdateTargetId { get; set; }
-    public string Confirm { get; set; }
+    public string? UpdateTargetId { get; set; }
+    public string? Confirm { get; set; }
     public int LoadingElementDuration { get; set; }
-    public string LoadingElementId { get; set; }
-    public string OnBegin { get; set; }
-    public string OnComplete { get; set; }
-    public string OnFailure { get; set; }
-    public string OnSuccess { get; set; }
-    public string Url { get; set; }
+    public string? LoadingElementId { get; set; }
+    public string? OnBegin { get; set; }
+    public string? OnComplete { get; set; }
+    public string? OnFailure { get; set; }
+    public string? OnSuccess { get; set; }
+    public string? Url { get; set; }
     public bool AllowCache { get; set; }
 }
 

--- a/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerBuilder.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerBuilder.cs
@@ -11,7 +11,7 @@ internal sealed class HtmlPagerBuilder : IHtmlPagerBuilder
 
     private Func<int, string> _generatePageUrl;
     private PagedListRenderOptions _options;
-    private string _partialViewName;
+    private string? _partialViewName;
 
     public HtmlPagerBuilder(IHtmlHelper htmlHelper, IPagedList pagedList)
     {
@@ -140,7 +140,7 @@ internal sealed class HtmlPagerBuilder : IHtmlPagerBuilder
         return this;
     }
 
-    public IHtmlContent Build(PagedListRenderOptions options)
+    public IHtmlContent Build(PagedListRenderOptions? options)
     {
         _options = options ?? _options;
 

--- a/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerExtensions.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerExtensions.cs
@@ -10,7 +10,7 @@ public static class HtmlPagerExtensions
 {
     public static IHtmlContent Pager(this IHtmlHelper htmlHelper)
     {
-        return new HtmlPagerBuilder(htmlHelper, Enumerable.Empty<object>().ToPagedList()).Build();
+        return new HtmlPagerBuilder(htmlHelper, Enumerable.Empty<object?>().ToPagedList()).Build();
     }
 
     public static IHtmlPagerBuilder Pager(this IHtmlHelper htmlHelper, IPagedList list)

--- a/src/X.PagedList.Mvc.Core/Fluent/IHtmlPagerBuilder.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/IHtmlPagerBuilder.cs
@@ -43,5 +43,5 @@ public interface IHtmlPagerBuilder
 
     IHtmlContent Build();
 
-    IHtmlContent Build(PagedListRenderOptions options);
+    IHtmlContent Build(PagedListRenderOptions? options);
 }

--- a/src/X.PagedList.Mvc.Core/GoToFormRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/GoToFormRenderOptions.cs
@@ -70,10 +70,10 @@ public class GoToFormRenderOptions
     /// <summary>
     /// Class that will be applied for input field
     /// </summary>
-    public String InputFieldClass { get; set; }
+    public string? InputFieldClass { get; set; }
 
     /// <summary>
     /// Class that will be applied for submit button
     /// </summary>
-    public string SubmitButtonClass { get; set; }
+    public string? SubmitButtonClass { get; set; }
 }

--- a/src/X.PagedList.Mvc.Core/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlHelper.cs
@@ -50,7 +50,7 @@ public class HtmlHelper
         return li;
     }
 
-    private TagBuilder WrapInListItem(TagBuilder inner, PagedListRenderOptions options, params string[] classes)
+    private TagBuilder WrapInListItem(TagBuilder inner, PagedListRenderOptions? options, params string[] classes)
     {
         var li = _tagBuilderFactory.Create("li");
 
@@ -233,7 +233,7 @@ public class HtmlHelper
             return WrapInListItem(previous, options, options.EllipsesElementClass, "disabled");
         }
 
-        var targetPageNumber = firstPageToDisplay - 1;
+        int targetPageNumber = firstPageToDisplay - 1;
 
         previous.Attributes.Add("href", generatePageUrl(targetPageNumber));
 
@@ -269,7 +269,7 @@ public class HtmlHelper
 
     #endregion Private methods
 
-    public string PagedListPager(IPagedList pagedList, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    public string? PagedListPager(IPagedList? pagedList, Func<int, string> generatePageUrl, PagedListRenderOptions options)
     {
         var list = pagedList ?? new StaticPagedList<int>(ImmutableList<int>.Empty, 1, 10, 0);
 
@@ -281,14 +281,14 @@ public class HtmlHelper
         var listItemLinks = new List<TagBuilder>();
 
         //calculate start and end of range of page numbers
-        var firstPageToDisplay = 1;
-        var lastPageToDisplay = list.PageCount;
-        var pageNumbersToDisplay = lastPageToDisplay;
+        int firstPageToDisplay = 1;
+        int lastPageToDisplay = list.PageCount;
+        int pageNumbersToDisplay = lastPageToDisplay;
 
         if (options.MaximumPageNumbersToDisplay.HasValue && list.PageCount > options.MaximumPageNumbersToDisplay)
         {
             // cannot fit all pages into pager
-            var maxPageNumbersToDisplay = options.MaximumPageNumbersToDisplay.Value;
+            int maxPageNumbersToDisplay = options.MaximumPageNumbersToDisplay.Value;
 
             firstPageToDisplay = list.PageNumber - maxPageNumbersToDisplay / 2;
 
@@ -341,7 +341,7 @@ public class HtmlHelper
                 listItemLinks.Add(PreviousEllipsis(list, generatePageUrl, options, firstPageToDisplay));
             }
 
-            foreach (var i in Enumerable.Range(firstPageToDisplay, pageNumbersToDisplay))
+            foreach (int i in Enumerable.Range(firstPageToDisplay, pageNumbersToDisplay))
             {
                 //show delimiter between page numbers
                 if (i > firstPageToDisplay && !string.IsNullOrWhiteSpace(options.DelimiterBetweenPageNumbers))

--- a/src/X.PagedList.Mvc.Core/HtmlHelperExtension.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlHelperExtension.cs
@@ -20,7 +20,7 @@ public static class HtmlHelperExtension
     ///<param name = "generatePageUrl">A function that takes the page number of the desired page and returns a URL-string that will load that page.</param>
     ///<returns>Outputs the paging control HTML.</returns>
     public static HtmlString PagedListPager(this IHtmlHelper html,
-        IPagedList list,
+        IPagedList? list,
         Func<int, string> generatePageUrl)
     {
         return PagedListPager(html, list, generatePageUrl, new PagedListRenderOptions());
@@ -35,12 +35,12 @@ public static class HtmlHelperExtension
     ///<param name = "options">Formatting options.</param>
     ///<returns>Outputs the paging control HTML.</returns>
     public static HtmlString PagedListPager(this IHtmlHelper html,
-        IPagedList list,
+        IPagedList? list,
         Func<int, string> generatePageUrl,
         PagedListRenderOptions options)
     {
-        var htmlHelper = new HtmlHelper(new TagBuilderFactory());
-        var htmlString = htmlHelper.PagedListPager(list, generatePageUrl, options);
+        HtmlHelper htmlHelper = new HtmlHelper(new TagBuilderFactory());
+        string? htmlString = htmlHelper.PagedListPager(list, generatePageUrl, options);
 
         htmlString = HttpUtility.HtmlDecode(htmlString);
 
@@ -88,8 +88,8 @@ public static class HtmlHelperExtension
         string formAction,
         GoToFormRenderOptions options)
     {
-        var htmlHelper = new HtmlHelper(new TagBuilderFactory());
-        var htmlString = htmlHelper.PagedListGoToPageForm(list, formAction, options);
+        HtmlHelper htmlHelper = new HtmlHelper(new TagBuilderFactory());
+        string htmlString = htmlHelper.PagedListGoToPageForm(list, formAction, options);
 
         return new HtmlString(htmlString);
     }

--- a/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
@@ -53,22 +53,22 @@ public class PagedListRenderOptions
     ///<summary>
     /// CSS Classes to append to the &lt;div&gt; element that wraps the paging control.
     ///</summary>
-    public IEnumerable<string> ContainerDivClasses { get; set; }
+    public IEnumerable<string>? ContainerDivClasses { get; set; }
 
     ///<summary>
     /// CSSClasses to append to the &lt;ul&gt; element in the paging control.
     ///</summary>
-    public IEnumerable<string> UlElementClasses { get; set; }
+    public IEnumerable<string>? UlElementClasses { get; set; }
 
     /// <summary>
     /// Attrinutes to appendto the &lt;ul&gt; element in the paging control
     /// </summary>
-    public IDictionary<string, string> UlElementattributes { get; set; }
+    public IDictionary<string, string>? UlElementattributes { get; set; }
 
     ///<summary>
     /// CSS Classes to append to every &lt;li&gt; element in the paging control.
     ///</summary>
-    public IEnumerable<string> LiElementClasses { get; set; }
+    public IEnumerable<string>? LiElementClasses { get; set; }
 
     /// <summary>
     /// CSS Classes to appent to active &lt;li&gt; element in the paging control.
@@ -78,7 +78,7 @@ public class PagedListRenderOptions
     ///<summary>
     /// CSS Classes to append to every &lt;a&gt; or &lt;span&gt; element that represent each page in the paging control.
     ///</summary>
-    public IEnumerable<string> PageClasses { get; set; }
+    public IEnumerable<string>? PageClasses { get; set; }
 
     ///<summary>
     /// CSS Classes to append to previous element in the paging control.
@@ -98,12 +98,12 @@ public class PagedListRenderOptions
     ///<summary>
     /// Specifies a CSS class to append to the first list item in the pager. If null or whitespace is defined, no additional class is added to first list item in list.
     ///</summary>
-    public string ClassToApplyToFirstListItemInPager { get; set; }
+    public string? ClassToApplyToFirstListItemInPager { get; set; }
 
     ///<summary>
     /// Specifies a CSS class to append to the last list item in the pager. If null or whitespace is defined, no additional class is added to last list item in list.
     ///</summary>
-    public string ClassToApplyToLastListItemInPager { get; set; }
+    public string? ClassToApplyToLastListItemInPager { get; set; }
 
     /// <summary>
     /// If set to Always, always renders the paging control. If set to IfNeeded, render the paging control when there is more than one page.
@@ -238,12 +238,12 @@ public class PagedListRenderOptions
     /// <summary>
     /// A function that will render each page number when specified (and DisplayLinkToIndividualPages is true). If no function is specified, the LinkToIndividualPageFormat value will be used instead.
     /// </summary>
-    public Func<int, string> FunctionToDisplayEachPageNumber { get; set; }
+    public Func<int, string>? FunctionToDisplayEachPageNumber { get; set; }
 
     /// <summary>
     /// Text that will appear between each page number. If null or whitespace is specified, no delimiter will be shown.
     /// </summary>
-    public string DelimiterBetweenPageNumbers { get; set; }
+    public string? DelimiterBetweenPageNumbers { get; set; }
 
     ///<summary>
     /// Also includes links to First and Last pages.
@@ -368,7 +368,7 @@ public class PagedListRenderOptions
     /// <summary>
     /// An extension point which allows you to fully customize the anchor tags used for clickable pages, as well as navigation features such as Next, Last, etc.
     /// </summary>
-    public Func<TagBuilder, TagBuilder, TagBuilder> FunctionToTransformEachPageLink { get; set; }
+    public Func<TagBuilder, TagBuilder, TagBuilder>? FunctionToTransformEachPageLink { get; set; }
 
     /// <summary>
     /// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.
@@ -376,7 +376,7 @@ public class PagedListRenderOptions
     /// <param name="pagedListRenderOptions"></param>
     /// <param name="ajaxOptions">The ajax options that will put into the link</param>
     /// <returns>The PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
-    public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(PagedListRenderOptions pagedListRenderOptions, AjaxOptions ajaxOptions)
+    public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(PagedListRenderOptions pagedListRenderOptions, AjaxOptions? ajaxOptions)
     {
         if (pagedListRenderOptions is PagedListRenderOptions renderOptions)
         {
@@ -431,7 +431,7 @@ public class PagedListRenderOptions
     /// </summary>
     /// <param name="ajaxOptions">Ajax options that will be used to generate the unobstrusive tags on the link</param>
     /// <returns>A default instance of PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
-    public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(AjaxOptions ajaxOptions)
+    public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(AjaxOptions? ajaxOptions)
     {
         return EnableUnobtrusiveAjaxReplacing(new PagedListRenderOptions(), ajaxOptions);
     }

--- a/src/X.PagedList.Mvc.Core/TagBuilderExtensions.cs
+++ b/src/X.PagedList.Mvc.Core/TagBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class TagBuilderExtensions
         tagBuilder.InnerHtml.AppendHtml(innerHtml);
     }
 
-    public static void MergeAttribute(this TagBuilder tagBuilder, string key, string value)
+    public static void MergeAttribute(this TagBuilder tagBuilder, string key, string? value)
     {
         tagBuilder
             .MergeAttribute(key, value);
@@ -30,11 +30,11 @@ public static class TagBuilderExtensions
         tagBuilder.InnerHtml.SetContent(innerText);
     }
 
-    public static string ToString(this TagBuilder tagBuilder, TagRenderMode renderMode, HtmlEncoder encoder = null)
+    public static string ToString(this TagBuilder tagBuilder, TagRenderMode renderMode, HtmlEncoder? encoder = null)
     {
         encoder ??= HtmlEncoder.Create(new TextEncoderSettings());
 
-        using (var writer = new StringWriter() as TextWriter)
+        using (var writer = new StringWriter())
         {
             tagBuilder.WriteTo(writer, encoder);
 

--- a/src/X.PagedList/BasePagedList.cs
+++ b/src/X.PagedList/BasePagedList.cs
@@ -63,18 +63,18 @@ public abstract class BasePagedList<T> : PagedListMetaData, IPagedList<T>
             ? (int)Math.Ceiling(TotalItemCount / (double)PageSize)
             : 0;
 
-        var pageNumberIsGood = PageCount > 0 && PageNumber <= PageCount;
+        bool pageNumberIsGood = PageCount > 0 && PageNumber <= PageCount;
 
         HasPreviousPage = pageNumberIsGood && PageNumber > 1;
         HasNextPage = pageNumberIsGood && PageNumber < PageCount;
         IsFirstPage = pageNumberIsGood && PageNumber == 1;
         IsLastPage = pageNumberIsGood && PageNumber == PageCount;
 
-        var numberOfFirstItemOnPage = (PageNumber - 1) * PageSize + 1;
+        int numberOfFirstItemOnPage = (PageNumber - 1) * PageSize + 1;
 
         FirstItemOnPage = pageNumberIsGood ? numberOfFirstItemOnPage : 0;
 
-        var numberOfLastItemOnPage = numberOfFirstItemOnPage + PageSize - 1;
+        int numberOfLastItemOnPage = numberOfFirstItemOnPage + PageSize - 1;
 
         LastItemOnPage = pageNumberIsGood
             ? numberOfLastItemOnPage > TotalItemCount

--- a/src/X.PagedList/PagedList.cs
+++ b/src/X.PagedList/PagedList.cs
@@ -25,20 +25,20 @@ public class PagedList<T, TKey> : BasePagedList<T>
     /// <param name="pageSize">The maximum size of any individual subset.</param>
     /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-    public PagedList(IQueryable<T> superset, Expression<Func<T, TKey>> keySelector, int pageNumber, int pageSize)
+    public PagedList(IQueryable<T>? superset, Expression<Func<T, TKey>> keySelector, int pageNumber, int pageSize)
         : base(pageNumber, pageSize, superset?.Count() ?? 0)
     {
         // add items to internal list
-        if (TotalItemCount > 0)
+        if (superset != null && TotalItemCount > 0)
         {
             InitSubset(superset, keySelector.Compile(), pageNumber, pageSize);
         }
     }
 
-    public PagedList(IQueryable<T> superset, Func<T, TKey> keySelectorMethod, int pageNumber, int pageSize)
+    public PagedList(IQueryable<T>? superset, Func<T, TKey> keySelectorMethod, int pageNumber, int pageSize)
         : base(pageNumber, pageSize, superset?.Count() ?? 0)
     {
-        if (TotalItemCount > 0)
+        if (superset != null && TotalItemCount > 0)
         {
             InitSubset(superset, keySelectorMethod, pageNumber, pageSize);
         }
@@ -67,7 +67,7 @@ public class PagedList<T, TKey> : BasePagedList<T>
 /// <seealso cref="IPagedList{T}"/>
 /// <seealso cref="BasePagedList{T}"/>
 /// <seealso cref="StaticPagedList{T}"/>
-/// <seealso cref="List{T}"/>    
+/// <seealso cref="List{T}"/>
 public class PagedList<T> : BasePagedList<T>
 {
     /// <summary>
@@ -86,10 +86,10 @@ public class PagedList<T> : BasePagedList<T>
     /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
     [PublicAPI]
-    public PagedList(IQueryable<T> superset, int pageNumber, int pageSize)
+    public PagedList(IQueryable<T>? superset, int pageNumber, int pageSize)
         : base(pageNumber, pageSize, superset?.Count() ?? 0)
     {
-        if (TotalItemCount > 0 && superset != null)
+        if (superset != null && TotalItemCount > 0)
         {
             var skip = (pageNumber - 1) * pageSize;
 
@@ -110,8 +110,8 @@ public class PagedList<T> : BasePagedList<T>
     /// <param name="pageSize">The maximum size of any individual subset.</param>
     /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
     /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-    public PagedList(IEnumerable<T> superset, int pageNumber, int pageSize)
-        : this(superset.AsQueryable<T>(), pageNumber, pageSize)
+    public PagedList(IEnumerable<T>? superset, int pageNumber, int pageSize)
+        : this(superset?.AsQueryable<T>(), pageNumber, pageSize)
     {
     }
 

--- a/src/X.PagedList/PagedListExtensions.cs
+++ b/src/X.PagedList/PagedListExtensions.cs
@@ -27,7 +27,7 @@ public static class PagedListExtensions
             throw new ArgumentNullException(nameof(superset));
         }
 
-        var take = Convert.ToInt32(Math.Ceiling(superset.Count() / (double)numberOfPages));
+        int take = Convert.ToInt32(Math.Ceiling(superset.Count() / (double)numberOfPages));
         var result = new List<IEnumerable<T>>();
 
         for (int i = 0; i < numberOfPages; i++)
@@ -60,7 +60,7 @@ public static class PagedListExtensions
         }
 
         // Cache this to avoid evaluating it twice
-        var count = superset.Count();
+        int count = superset.Count();
 
         if (count < pageSize)
         {
@@ -111,8 +111,8 @@ public static class PagedListExtensions
             throw new ArgumentNullException(nameof(superset));
         }
 
-        var supersetSize = superset.Count();
-        var pageSize = supersetSize == 0 ? 1 : supersetSize;
+        int supersetSize = superset.Count();
+        int pageSize = supersetSize == 0 ? 1 : supersetSize;
 
         return new PagedList<T>(superset, 1, pageSize);
     }

--- a/src/X.PagedList/PagedListMetaData.cs
+++ b/src/X.PagedList/PagedListMetaData.cs
@@ -4,7 +4,7 @@ namespace X.PagedList;
 
 ///<summary>
 /// Non-enumerable version of the PagedList class.
-///</summary>    
+///</summary>
 [PublicAPI]
 public class PagedListMetaData : IPagedList
 {

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -5,6 +5,8 @@
 
         <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>default</LangVersion>
+
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -5,8 +5,6 @@
 
         <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>default</LangVersion>
-
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/X.PagedList.Tests/Blog.cs
+++ b/tests/X.PagedList.Tests/Blog.cs
@@ -4,7 +4,7 @@ public class Blog
 {
     public int BlogID { get; set; }
 
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public string Url { get; set; }
+    public string? Url { get; set; }
 }

--- a/tests/X.PagedList.Tests/IDbAsyncEnumerator.cs
+++ b/tests/X.PagedList.Tests/IDbAsyncEnumerator.cs
@@ -1,4 +1,4 @@
 ﻿namespace X.PagedList.Tests;
 
 public interface IDbAsyncEnumerator<T> : IDbAsyncEnumerator { }
-public interface IDbAsyncEnumerator { object Current { get; } }
+public interface IDbAsyncEnumerator { object? Current { get; } }

--- a/tests/X.PagedList.Tests/PagedListFacts.cs
+++ b/tests/X.PagedList.Tests/PagedListFacts.cs
@@ -67,8 +67,8 @@ public class PagedListFacts
     {
         var collection = Enumerable.Range(1, 1000000);
 
-        var pageNumber = 2;
-        var pageSize = 10;
+        int pageNumber = 2;
+        int pageSize = 10;
 
         Expression<Func<int, int>> keySelector = i => Order(i);
 
@@ -339,9 +339,9 @@ public class PagedListFacts
     [Fact]
     public async Task ToListAsync_Check_CornerCases()
     {
-        var pageNumber = 2;
-        var pageSize = 10;
-        var superSetTotalCount = 110;
+        int pageNumber = 2;
+        int pageSize = 10;
+        int superSetTotalCount = 110;
 
         var superset = BuildBlogList(50);
         var queryable = superset.AsQueryable();
@@ -365,9 +365,9 @@ public class PagedListFacts
     [Fact]
     public async Task ToListAsync_Check_CornerCases_For_Enumerable()
     {
-        var pageNumber = 2;
-        var pageSize = 10;
-        var superSetTotalCount = 110;
+        int pageNumber = 2;
+        int pageSize = 10;
+        int superSetTotalCount = 110;
 
         var superset = BuildBlogList(50);
         var enumerable = superset.AsEnumerable();
@@ -391,9 +391,9 @@ public class PagedListFacts
     [Fact]
     public async Task ClonePagedList()
     {
-        var pageNumber = 2;
-        var pageSize = 10;
-        var superSetTotalCount = 110;
+        int pageNumber = 2;
+        int pageSize = 10;
+        int superSetTotalCount = 110;
 
         var superset1 = BuildBlogList(50);
         var superset2 = BuildBlogList(10);
@@ -413,9 +413,9 @@ public class PagedListFacts
     [Fact]
     public async Task Check_Ctor_With_KeySelectorMethod()
     {
-        var pageNumber = 2;
-        var pageSize = 10;
-        var superSetTotalCount = 110;
+        int pageNumber = 2;
+        int pageSize = 10;
+        int superSetTotalCount = 110;
 
         var collection = BuildBlogList(50);
 

--- a/tests/X.PagedList.Tests/PagedListTheories.cs
+++ b/tests/X.PagedList.Tests/PagedListTheories.cs
@@ -43,8 +43,8 @@ public class PagedListTheories
     {
         pageNumber = pageNumber.HasValue == false ? 0 : pageNumber;
 
-        var listPageNumber = pageNumber != 0 ? (pageNumber ?? 1) - 1 : (pageNumber ?? 1);
-        var xListPageNumber = pageNumber == 0 ? 1 : (pageNumber ?? 1);
+        int listPageNumber = pageNumber != 0 ? (pageNumber ?? 1) - 1 : (pageNumber ?? 1);
+        int xListPageNumber = pageNumber == 0 ? 1 : (pageNumber ?? 1);
 
         var superset = BuildBlogList(1000);
 
@@ -79,7 +79,7 @@ public class PagedListTheories
         bool expectedHasPrevious, bool expectedHasNext)
     {
         //arrange
-        var data = integers;
+        int[] data = integers;
 
         //act
         var pagedList = data.ToPagedList(pageNumber, pageSize);
@@ -100,7 +100,7 @@ public class PagedListTheories
         bool expectedIsFirstPage, bool expectedIsLastPage)
     {
         //arrange
-        var data = integers;
+        int[] data = integers;
 
         //act
         var pagedList = data.ToPagedList(pageNumber, pageSize);
@@ -121,7 +121,7 @@ public class PagedListTheories
     public void Theory_PageCount_Is_Correct(int[] integers, int pageSize, int expectedNumberOfPages)
     {
         //arrange
-        var data = integers;
+        int[] data = integers;
 
         //act
         var pagedList = data.ToPagedList(1, pageSize);
@@ -140,7 +140,7 @@ public class PagedListTheories
     public void Theory_FirstItemOnPage_And_LastItemOnPage_Are_Correct(int[] integers, int pageNumber, int pageSize, int expectedFirstItemOnPage, int expectedLastItemOnPage)
     {
         //arrange
-        var data = integers;
+        int[] data = integers;
 
         //act
         var pagedList = data.ToPagedList(pageNumber, pageSize);

--- a/tests/X.PagedList.Tests/StaticPagedListFacts.cs
+++ b/tests/X.PagedList.Tests/StaticPagedListFacts.cs
@@ -13,7 +13,7 @@ public class StaticPagedListFacts
     public void StaticPagedList_uses_supplied_totalItemCount_to_determine_subsets_position_within_superset(int pageNumber, bool shouldBeFirstPage, bool shouldBeLastPage)
     {
         //arrange
-        var subset = new[] { 1, 1, 1 };
+        int[] subset = new[] { 1, 1, 1 };
 
         //act
         var list = new StaticPagedList<int>(subset, pageNumber, 3, 9);
@@ -28,7 +28,7 @@ public class StaticPagedListFacts
     public void TotalItemCount_Below_One_Throws_Exception()
     {
         //arrange
-        var data = new[] { 1, 2, 3, 4, 5 };
+        int[] data = new[] { 1, 2, 3, 4, 5 };
 
         //assert
         Assert.Throws<ArgumentOutOfRangeException>(() => new StaticPagedList<int>(data, 1, 10, -1));

--- a/tests/X.PagedList.Tests/TestContext.cs
+++ b/tests/X.PagedList.Tests/TestContext.cs
@@ -2,5 +2,5 @@
 
 public class TestContext : DbContext
 {
-    public virtual DbSet<Blog> Blogs { get; set; }
+    public virtual DbSet<Blog>? Blogs { get; set; }
 }

--- a/tests/X.PagedList.Tests/TestDbAsyncQueryProvider.cs
+++ b/tests/X.PagedList.Tests/TestDbAsyncQueryProvider.cs
@@ -26,7 +26,7 @@ internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
         return new TestDbAsyncEnumerable<TElement>(expression);
     }
 
-    public object Execute(Expression expression)
+    public object? Execute(Expression expression)
     {
         return _inner.Execute(expression);
     }
@@ -36,7 +36,7 @@ internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
         return _inner.Execute<TResult>(expression);
     }
 
-    public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
+    public Task<object?> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
     {
         return Task.FromResult(Execute(expression));
     }
@@ -96,7 +96,7 @@ internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
             get { return _inner.Current; }
         }
 
-        object IDbAsyncEnumerator.Current
+        object? IDbAsyncEnumerator.Current
         {
             get { return Current; }
         }
@@ -142,7 +142,7 @@ internal class TestDbAsyncQueryProvider<TEntity> : IDbAsyncQueryProvider
 
             public T Current => _enumerator.Current;
 
-            object IDbAsyncEnumerator.Current => Current;
+            object? IDbAsyncEnumerator.Current => Current;
         }
     }
 }

--- a/tests/X.PagedList.Tests/X.PagedList.Tests.csproj
+++ b/tests/X.PagedList.Tests/X.PagedList.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This enables nullable annotations for the remaining core projects and adjusts the variable/argument/property types accordingly.

This is based on (and includes) #267 

Since I change csproj files, this conflicts with #265 
If you intend to merge both, please merge one of them first and let me rebase the other one before merging it.