### PR TITLE
X.PagedList.Mvc.Core: Improve nullable handling for generatePageUrl

### DIFF
--- a/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerBuilder.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerBuilder.cs
@@ -9,7 +9,7 @@ internal sealed class HtmlPagerBuilder : IHtmlPagerBuilder
     private readonly IHtmlHelper _htmlHelper;
     private readonly IPagedList _pagedList;
 
-    private Func<int, string> _generatePageUrl;
+    private Func<int, string?> _generatePageUrl;
     private PagedListRenderOptions _options;
     private string? _partialViewName;
 
@@ -21,7 +21,7 @@ internal sealed class HtmlPagerBuilder : IHtmlPagerBuilder
         _options = new PagedListRenderOptions();
     }
 
-    public IHtmlPagerBuilder Url(Func<int, string> builder)
+    public IHtmlPagerBuilder Url(Func<int, string?> builder)
     {
         _generatePageUrl = builder;
 

--- a/src/X.PagedList.Mvc.Core/Fluent/IHtmlPagerBuilder.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/IHtmlPagerBuilder.cs
@@ -7,7 +7,7 @@ namespace X.PagedList.Mvc.Core.Fluent;
 [PublicAPI]
 public interface IHtmlPagerBuilder
 {
-    IHtmlPagerBuilder Url(Func<int, string> builder);
+    IHtmlPagerBuilder Url(Func<int, string?> builder);
 
     IHtmlPagerBuilder DisplayLinkToFirstPage(PagedListDisplayMode displayMode = PagedListDisplayMode.Always);
 

--- a/src/X.PagedList.Mvc.Core/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlHelper.cs
@@ -69,7 +69,7 @@ public class HtmlHelper
         return li;
     }
 
-    private TagBuilder First(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    private TagBuilder First(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         const int targetPageNumber = 1;
         var first = _tagBuilderFactory
@@ -92,7 +92,7 @@ public class HtmlHelper
         return WrapInListItem(first, options, "PagedList-skipToFirst");
     }
 
-    private TagBuilder Previous(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    private TagBuilder Previous(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         var targetPageNumber = list.PageNumber - 1;
         var previous = _tagBuilderFactory
@@ -117,7 +117,7 @@ public class HtmlHelper
         return WrapInListItem(previous, options, options.PreviousElementClass);
     }
 
-    private TagBuilder Page(int i, IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    private TagBuilder Page(int i, IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         var format = options.FunctionToDisplayEachPageNumber
                      ?? (pageNumber => string.Format(options.LinkToIndividualPageFormat, pageNumber));
@@ -145,7 +145,7 @@ public class HtmlHelper
         return WrapInListItem(page, options);
     }
 
-    private TagBuilder Next(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    private TagBuilder Next(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         var targetPageNumber = list.PageNumber + 1;
         var next = _tagBuilderFactory
@@ -170,7 +170,7 @@ public class HtmlHelper
         return WrapInListItem(next, options, options.NextElementClass);
     }
 
-    private TagBuilder Last(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    private TagBuilder Last(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         var targetPageNumber = list.PageCount;
         var last = _tagBuilderFactory
@@ -213,7 +213,7 @@ public class HtmlHelper
         return WrapInListItem(text, options, "PagedList-pageCountAndLocation", "disabled");
     }
 
-    private TagBuilder PreviousEllipsis(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options, int firstPageToDisplay)
+    private TagBuilder PreviousEllipsis(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options, int firstPageToDisplay)
     {
         var previous = _tagBuilderFactory
             .Create("a");
@@ -240,7 +240,7 @@ public class HtmlHelper
         return WrapInListItem(previous, options, options.EllipsesElementClass);
     }
 
-    private TagBuilder NextEllipsis(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options, int lastPageToDisplay)
+    private TagBuilder NextEllipsis(IPagedList list, Func<int, string?> generatePageUrl, PagedListRenderOptions options, int lastPageToDisplay)
     {
         var next = _tagBuilderFactory
             .Create("a");
@@ -269,7 +269,7 @@ public class HtmlHelper
 
     #endregion Private methods
 
-    public string? PagedListPager(IPagedList? pagedList, Func<int, string> generatePageUrl, PagedListRenderOptions options)
+    public string? PagedListPager(IPagedList? pagedList, Func<int, string?> generatePageUrl, PagedListRenderOptions options)
     {
         var list = pagedList ?? new StaticPagedList<int>(ImmutableList<int>.Empty, 1, 10, 0);
 

--- a/src/X.PagedList.Mvc.Core/HtmlHelperExtension.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlHelperExtension.cs
@@ -21,7 +21,7 @@ public static class HtmlHelperExtension
     ///<returns>Outputs the paging control HTML.</returns>
     public static HtmlString PagedListPager(this IHtmlHelper html,
         IPagedList? list,
-        Func<int, string> generatePageUrl)
+        Func<int, string?> generatePageUrl)
     {
         return PagedListPager(html, list, generatePageUrl, new PagedListRenderOptions());
     }
@@ -36,7 +36,7 @@ public static class HtmlHelperExtension
     ///<returns>Outputs the paging control HTML.</returns>
     public static HtmlString PagedListPager(this IHtmlHelper html,
         IPagedList? list,
-        Func<int, string> generatePageUrl,
+        Func<int, string?> generatePageUrl,
         PagedListRenderOptions options)
     {
         HtmlHelper htmlHelper = new HtmlHelper(new TagBuilderFactory());


### PR DESCRIPTION
We only ever use the generatePageUrl argument (in various places) to set HTML attribute values with TagBuilder.Attributes.Add().

The latter specifically accepts nullable strings for the value. Thus, this commits adjusts the return type of the `Func<int, string>` for generatePageUrl to be nullable as well, i.e. to `Func<int, string?>`, for all affected cases.

This removes nullable warnings for actual use cases like the following:

  @Html.PagedListPager(someModel, page => Url.Action(...), ...)

Here, Url.Action returns `string?` and thus creates a nullable warning CS8603 with the implementation before this commit. Since TagBuilder.Attributes.Add() allows `string?`, though, we can be more permissive here and do so with this commit.

---

This has been found while testing 10.0.0-pre