### PR TITLE
Treewide: Provide specific namespace for Extensions (again)

### DIFF
--- a/examples/Example.Website/Controllers/AdminController.cs
+++ b/examples/Example.Website/Controllers/AdminController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using X.PagedList;
+using X.PagedList.Extensions;
 
 namespace Example.Website.Controllers;
 

--- a/examples/Example.Website/Controllers/HomeController.cs
+++ b/examples/Example.Website/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using X.PagedList;
+using X.PagedList.Extensions;
 
 namespace Example.Website.Controllers;
 

--- a/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerExtensions.cs
+++ b/src/X.PagedList.Mvc.Core/Fluent/HtmlPagerExtensions.cs
@@ -2,6 +2,7 @@
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using X.PagedList.Extensions;
 
 namespace X.PagedList.Mvc.Core.Fluent;
 

--- a/src/X.PagedList/Extensions/PagedListExtensions.cs
+++ b/src/X.PagedList/Extensions/PagedListExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 
-namespace X.PagedList;
+namespace X.PagedList.Extensions;
 
 /// <summary>
 /// Container for extension methods designed to simplify the creation of instances of <see cref="PagedList{T}"/>.

--- a/src/X.PagedList/X.PagedList.csproj
+++ b/src/X.PagedList/X.PagedList.csproj
@@ -11,12 +11,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="../../README.md" Pack="true" PackagePath=""/>
-        <None Include="../../LICENSE.md" Pack="true" PackagePath=""/>
+        <None Include="../../README.md" Pack="true" PackagePath="" />
+        <None Include="../../LICENSE.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" PrivateAssets="all"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/tests/X.PagedList.Tests/PagedListExample.cs
+++ b/tests/X.PagedList.Tests/PagedListExample.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using X.PagedList.Extensions;
 
 namespace X.PagedList.Tests;
 

--- a/tests/X.PagedList.Tests/PagedListFacts.cs
+++ b/tests/X.PagedList.Tests/PagedListFacts.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using X.PagedList.Extensions;
 using Xunit;
 
 namespace X.PagedList.Tests;

--- a/tests/X.PagedList.Tests/PagedListTheories.cs
+++ b/tests/X.PagedList.Tests/PagedListTheories.cs
@@ -1,5 +1,6 @@
 ﻿using AutoFixture;
 using System.Linq;
+using X.PagedList.Extensions;
 using Xunit;
 
 namespace X.PagedList.Tests;

--- a/tests/X.PagedList.Tests/SplitAndPartitionFacts.cs
+++ b/tests/X.PagedList.Tests/SplitAndPartitionFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using X.PagedList.Extensions;
 using Xunit;
 
 namespace X.PagedList.Tests;


### PR DESCRIPTION
As discussed in [1], using a separate namespace for Extensions has several advantages. Unfortunately, the dedicated namespace for the PagedListExtensions has been removed during the package name rearrangements and not added back after.

This commit adds it back and essentially reverts the namespace scheme to where it was in v10.0.3, like already done for the rest of the code.

To indicate this more prominently, the PagedListExtensions.cs class is moved into an "Extensions" subfolder, so the namespace now also matches the folder structure.

From the released packages, this affects X.PagedList and X.PagedList.Mvc.Core.

[1] 6ae094e4bd45 ("Treewide: Provide specific namespaces for Extensions")

Fixes: #290