### PR TITLE
Support EF7 with dotnet7

### DIFF
--- a/src/X.PagedList.EF/X.PagedList.EF.csproj
+++ b/src/X.PagedList.EF/X.PagedList.EF.csproj
@@ -5,7 +5,7 @@
         <Description>EF extensions for X.PagedList library</Description>
 
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 
         <PackageTags>paging pagedlist paged list entity framework ef</PackageTags>
     </PropertyGroup>
@@ -18,7 +18,7 @@
         <None Include="../../LICENSE.md" Pack="true" PackagePath=""/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net7.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[7.0.20,8)"/>
     </ItemGroup>
 


### PR DESCRIPTION
Current config requires EF 8 if using dotnet 7. This change will allow either EF7 or EF8 to be used.