### PR TITLE
Allow EF7 to be used with .NET 8

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,10 +10,10 @@
         <Copyright>Andrew Gubskiy © 2024</Copyright>
         <Company>Ukrainian .NET Developer Community</Company>
 
-        <Version>10.5.2-pre</Version>
-        <AssemblyVersion>10.5.2</AssemblyVersion>
-        <FileVersion>10.5.2</FileVersion>
-        <PackageVersion>10.5.2-pre</PackageVersion>
+        <Version>10.5.3-pre</Version>
+        <AssemblyVersion>10.5.3</AssemblyVersion>
+        <FileVersion>10.5.3</FileVersion>
+        <PackageVersion>10.5.3-pre</PackageVersion>
 
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/dncuug/X.PagedList.git</RepositoryUrl>

--- a/src/X.PagedList.EF/X.PagedList.EF.csproj
+++ b/src/X.PagedList.EF/X.PagedList.EF.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Further discussion around supporting EF7 with .NET 8 https://github.com/dncuug/X.PagedList/pull/300#issuecomment-2408977400

This PR effectively reverts the original proposal and slides the minimum required EF version back to 7.0.20 from 8+