### PR TITLE
src: Mvc.Core: Make HtmlAttribute properties non-null

### DIFF
--- a/src/X.PagedList.Mvc.Core/HtmlAttribute.cs
+++ b/src/X.PagedList.Mvc.Core/HtmlAttribute.cs
@@ -8,6 +8,11 @@ namespace X.PagedList.Mvc.Core;
 /// </remarks>
 public class HtmlAttribute
 {
-    public string Key { get; set; } = "";
-    public object? Value { get; set; }
+#if NET6_0
+    public string Key { get; set; } = string.Empty;
+    public object Value { get; set; } = string.Empty;
+#else
+    public required string Key { get; set; }
+    public required object Value { get; set; }
+#endif
 }

--- a/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc.Core/PagedListRenderOptions.cs
@@ -390,7 +390,7 @@ public class PagedListRenderOptions
                 {
                     foreach (var ajaxOption in ajaxOptions.ToUnobtrusiveHtmlAttributes())
                     {
-                        aTagBuilder.Attributes.Add(ajaxOption.Key, ajaxOption.Value?.ToString() ?? "");
+                        aTagBuilder.Attributes.Add(ajaxOption.Key, ajaxOption.Value.ToString() ?? "");
                     }
                 }
 


### PR DESCRIPTION
There is no point in setting either Key or Value of the HtmlAttribute to "null" or not set one of them at all. For this particular purpose, the "required" modifier was introduced in C# 11.

Use it where possible (.NET 7+) and provide non-null default values otherwise (.NET 6).