### PR TITLE
Request removes [Obsolete] attribute

### DIFF
--- a/src/X.PagedList/BasePagedList.cs
+++ b/src/X.PagedList/BasePagedList.cs
@@ -169,6 +169,5 @@ public abstract class BasePagedList<T> : IPagedList<T>
     /// Gets a non-enumerable copy of this paged list.
     /// </summary>
     /// <returns>A non-enumerable copy of this paged list.</returns>
-    [Obsolete("This method will be removed in future versions")]
     public PagedListMetaData GetMetaData() => new(this);
 }

--- a/src/X.PagedList/IPagedList.cs
+++ b/src/X.PagedList/IPagedList.cs
@@ -15,7 +15,6 @@ public interface IPagedList<out T> : IPagedList, IReadOnlyList<T>
     /// Gets a non-enumerable copy of this paged list.
     /// </summary>
     /// <returns>A non-enumerable copy of this paged list.</returns>
-    [Obsolete("This method will be removed in future versions")]
     PagedListMetaData GetMetaData();
 }
 

--- a/src/X.PagedList/PagedListMetaData.cs
+++ b/src/X.PagedList/PagedListMetaData.cs
@@ -5,7 +5,6 @@ namespace X.PagedList;
 /// <summary>
 /// Non-enumerable version of the PagedList class.
 /// </summary>
-[Obsolete("This class will be removed in future versions")]
 public class PagedListMetaData : IPagedList
 {
     /// <summary>


### PR DESCRIPTION
This pull request removes `[Obsolete]` attribute annotations from the `PagedListMetaData` class and its related `GetMetaData` methods. These changes indicate that the class and methods are no longer marked for future removal, making them officially supported again.

API status updates:

* Removed the `[Obsolete]` attribute from the `PagedListMetaData` class in `PagedListMetaData.cs`, making it officially supported.
* Removed the `[Obsolete]` attribute from the `GetMetaData` method in the `IPagedList<T>` interface in `IPagedList.cs`.
* Removed the `[Obsolete]` attribute from the `GetMetaData` method implementation in `BasePagedList.cs`.…tation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed obsolete/deprecation markings from pagination metadata types and the related API method. Signatures and behavior remain unchanged.
  - Eliminates deprecation warnings in consuming projects and clarifies continued support for these APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->